### PR TITLE
Add whileloop to avoid incomplete URL

### DIFF
--- a/PyBypass/VideoServers/streamtape_bypass.py
+++ b/PyBypass/VideoServers/streamtape_bypass.py
@@ -1,6 +1,6 @@
 import requests
 import re
-
+import time
 
 """
 Website : streamtape.com | streamtape.xyz | streamtape.to
@@ -15,8 +15,11 @@ Note: Bypassed url only open/download with the ip of machine you are working on
 """
 
 def streamtape_bypass( url:str)-> str:
-    response = requests.get(url)
-
-    if (videolink := re.findall(r"document.*((?=id\=)[^\"']+)", response.text)):
+    while True:
+        response = requests.get(url)
+        videolink = re.findall(r"document.*((?=id\=)[^\"']+)", response.text)
         nexturl = "https://streamtape.com/get_video?" + videolink[-1]
-        return nexturl
+        if len(nexturl) > 50:
+            return nexturl
+        print("Incomplete URL, retrying in 2 seconds...")
+        time.sleep(2)


### PR DESCRIPTION
Add While loop to rerun function till it gets right URL.

### reason
sometimes module gives 
`https://streamtape.com/get_video ` as output. To solve this I added while loop.